### PR TITLE
Fix utils import, doc path, typo and add auth test

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -202,7 +202,7 @@ Request:
 Response: Attendance[]
 ```
 
-### GET /api/teams/:teamId/attendance/players/:playerId
+### GET /api/teams/:teamId/attendance/player/:playerId
 Get attendance records for a specific player
 ```typescript
 Query Parameters:

--- a/server/__tests__/session-routes.test.ts
+++ b/server/__tests__/session-routes.test.ts
@@ -78,12 +78,26 @@ describe('Session Routes', () => {
       expect(response.body[0].id).toBe(1);
       expect(response.body[1].id).toBe(2);
     });
-    
+
     it('should handle invalid team ID', async () => {
       const response = await request(app).get('/api/teams/invalid/sessions');
-      
+
       expect(response.status).toBe(400);
       expect(response.body.error).toBe('Invalid Request');
+    });
+
+    it('should return 401 if user is not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use('/api/teams/:teamId/sessions', createSessionsRouter(mockStorage));
+
+      const response = await request(unauthApp).get('/api/teams/1/sessions');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({
+        error: 'Authentication Required',
+        message: 'You must be logged in to view session balances'
+      });
     });
   });
   

--- a/server/routes/utils.ts
+++ b/server/routes/utils.ts
@@ -2,6 +2,7 @@ import { Response } from "express";
 import { ZodError } from "zod";
 import { fromZodError } from "zod-validation-error";
 import { Player } from "@shared/schema";
+import { IStorage } from "../storage";
 
 /**
  * Error handler for validation errors

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -55,7 +55,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,


### PR DESCRIPTION
## Summary
- add missing IStorage import in utils router helpers
- correct attendance endpoint path in API docs
- fix typo in server vite comment
- add unauthorized access test for sessions routes

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840679046c88325a148636f6516c0ff